### PR TITLE
Always build against oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=41.2", "cython", "wheel", "numpy"]
+requires = ["setuptools>=41.2", "cython", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This prevents confusing ABI breaks when building cftime from source in an environment with an older numpy version.

For example: numpy 1.22 recently released, so pip will now pull that version into the isolated build environment for cftime.
However, the venv it's installing cftime into still has numpy 1.21, so the resulting cftime binaries will not be able to work in that venv, resulting in errors like:

```
File "src/cftime/_cftime.pyx", line 1, in init cftime._cftime
ValueError: numpy.ufunc size changed, may indicate binary incompatibility. Expected 232 from C header, got 216 from PyObject
```

The usual fix for that is to instead pull the oldest possible numpy version into the isolated build-env, for which purpose a special meta-package already exists. Since numpy guaranteeds ABI backwards compat, no matter what numpy version ends up installed in the venv, cftime will work.